### PR TITLE
PBL-21664 CloudPebble YCM proxy fails to create new files in empty projects

### DIFF
--- a/filesync.py
+++ b/filesync.py
@@ -1,6 +1,7 @@
 __author__ = 'katharine'
 
 import os.path
+import errno
 
 
 class FileSync(object):
@@ -71,6 +72,14 @@ class FileSync(object):
 
     def create_file(self, path, content):
         path = self.abs_path(path)
+        dir_name = os.path.dirname(path)
+        try:
+            os.makedirs(dir_name)
+        except OSError as e:
+            if e.errno == errno.EEXIST and os.path.isdir(dir_name):
+                pass
+            else:
+                raise
         with open(path, 'w') as f:
             f.write(content)
 


### PR DESCRIPTION
In new empty projects, the /src directory does not exist in the temporary directory created when the YCM proxy spins up. As a result, YCM fails to add new files and throws an exception at open(path, 'w'). 

The browser then resends a spinup request with the listing of files, and the result is that YCM-proxy creates two temporary directories instead of one, and twice as much bandwidth is used.

I'm not sure if this is the _best_ way of fixing it, but it works. We could create the "/src" directory manually at spinup, too.