### PR TITLE
PBL-35060 file rename can break YCM

### DIFF
--- a/filesync.py
+++ b/filesync.py
@@ -37,8 +37,8 @@ class FileSync(object):
                     merged_line += lines[end['line']][end['ch']:]
                 content.append(merged_line)
                 # Add the lines from the end through to the end.
-                if len(lines) > end['line']+1:
-                    content.extend(lines[end['line']+1:])
+                if len(lines) > end['line'] + 1:
+                    content.extend(lines[end['line'] + 1:])
 
             # Writeback.
             with open(abs_path, 'w') as f:
@@ -56,6 +56,13 @@ class FileSync(object):
                 raise
         with open(path, 'w') as f:
             f.write(content)
+
+    def rename_file(self, path, new_path):
+        path = self.abs_path(path)
+        new_path = self.abs_path(new_path)
+        if os.path.exists(new_path):
+            raise Exception("Cannot rename file, path already exists")
+        os.rename(path, new_path)
 
     def delete_file(self, path):
         path = self.abs_path(path)

--- a/proxy.py
+++ b/proxy.py
@@ -38,10 +38,11 @@ def server_ws(process_uuid):
         'goto': ycm_helpers.go_to,
         'create': ycm_helpers.create_file,
         'delete': ycm_helpers.delete_file,
-        'ping': ycm_helpers.ping,
+        'rename': ycm_helpers.rename_file,
         'resources': ycm_helpers.update_resources,
         'messagekeys': ycm_helpers.update_messagekeys,
-        'dependencies': ycm_helpers.update_dependencies
+        'dependencies': ycm_helpers.update_dependencies,
+        'ping': ycm_helpers.ping
     }
 
     # Get the WebSocket from the request context
@@ -82,7 +83,8 @@ def server_ws(process_uuid):
             # Run the specified command with the correct uuid and data
             try:
                 print "Running command: %s" % command
-                result = ws_commands[command](process_uuid, data)
+                ycms = ycm_helpers.get_ycms(process_uuid)
+                result = ws_commands[command](ycms, data)
             except ycm_helpers.YCMProxyException as e:
                 respond(packet_id, e.message, success=False)
                 continue

--- a/ycm_helpers.py
+++ b/ycm_helpers.py
@@ -123,10 +123,7 @@ def spinup(content):
     return dict(success=True, uuid=this_uuid)
 
 
-def get_completions(process_uuid, data):
-    if process_uuid not in mapping:
-        raise YCMProxyException("UUID not found")
-    ycms = mapping[process_uuid]
+def get_completions(ycms, data):
     if 'patches' in data:
         ycms.filesync.apply_patches(data['patches'])
     completions = collections.OrderedDict()
@@ -147,10 +144,13 @@ def get_completions(process_uuid, data):
     )
 
 
-def get_errors(process_uuid, data):
+def get_ycms(process_uuid):
     if process_uuid not in mapping:
         raise YCMProxyException("UUID not found")
-    ycms = mapping[process_uuid]
+    return mapping[process_uuid]
+
+
+def get_errors(ycms, data):
     if 'patches' in data:
         ycms.filesync.apply_patches(data['patches'])
     errors = {}
@@ -173,10 +173,7 @@ def get_errors(process_uuid, data):
     )
 
 
-def go_to(process_uuid, data):
-    if process_uuid not in mapping:
-        raise YCMProxyException("UUID not found")
-    ycms = mapping[process_uuid]
+def go_to(ycms, data):
     if 'patches' in data:
         ycms.filesync.apply_patches(data['patches'])
     for platform, ycm in sorted(ycms.ycms.iteritems(), reverse=True):
@@ -187,10 +184,7 @@ def go_to(process_uuid, data):
     return dict(location=None)
 
 
-def update_dependencies(process_uuid, data):
-    if process_uuid not in mapping:
-        raise YCMProxyException("UUID not found")
-    ycms = mapping[process_uuid]
+def update_dependencies(ycms, data):
     info = ycms.projectinfo
     filesync = ycms.filesync
     install_dependencies(data['dependencies'], filesync.root_dir)
@@ -203,44 +197,34 @@ def update_dependencies(process_uuid, data):
     filesync.create_file(MESSAGEKEY_HEADER_NAME, info.make_messagekey_header())
 
 
-def update_resources(process_uuid, data):
-    if process_uuid not in mapping:
-        raise YCMProxyException("UUID not found")
-    ycms = mapping[process_uuid]
+def update_resources(ycms, data):
     info = ycms.projectinfo
     filesync = ycms.filesync
     info.resources = data['resources']
     filesync.create_file(RESOURCE_HEADER_NAME, info.make_resource_ids_header())
 
 
-def update_messagekeys(process_uuid, data):
-    if process_uuid not in mapping:
-        raise YCMProxyException("UUID not found")
-    ycms = mapping[process_uuid]
+def update_messagekeys(ycms, data):
     info = ycms.projectinfo
     filesync = ycms.filesync
     info.messagekeys = data['messagekeys']
     filesync.create_file(MESSAGEKEY_HEADER_NAME, info.make_messagekey_header())
 
 
-def create_file(process_uuid, data):
-    if process_uuid not in mapping:
-        raise YCMProxyException("UUID not found")
-    ycms = mapping[process_uuid]
+def create_file(ycms, data):
     ycms.filesync.create_file(data['filename'], data['content'])
 
 
-def delete_file(process_uuid, data):
-    if process_uuid not in mapping:
-        raise YCMProxyException("UUID not found")
-    ycms = mapping[process_uuid]
+def delete_file(ycms, data):
     ycms.filesync.delete_file(data['filename'])
 
 
-def ping(process_uuid, data=None):
-    if process_uuid not in mapping:
-        raise YCMProxyException("UUID not found")
-    for ycm in mapping[process_uuid].ycms.itervalues():
+def rename_file(ycms, data):
+    ycms.filesync.rename_file(data['filename'], data['new_filename'])
+
+
+def ping(ycms, data=None):
+    for ycm in ycms.ycms.itervalues():
         if not ycm.ping():
             raise YCMProxyException("Failed to ping YCM")
 


### PR DESCRIPTION
YCM proxy was missing the ability to rename files, so there were cases where autocompletions would break for a renamed file. This adds the missing support.