### PR TITLE
Send headers to cloudpebble

### DIFF
--- a/npm_helpers.py
+++ b/npm_helpers.py
@@ -113,13 +113,6 @@ def extract_library_headers(root_dir):
             raise NPMInstallError("One or more of your dependencies is not a valid pebble library.")
 
 
-def _startswith_any(str, options):
-    for x in options:
-        if str.startswith(x):
-            return x
-    return None
-
-
 def make_library_info(dependencies, versions, headers):
     libs = {}
     for name, version in versions.iteritems():
@@ -130,7 +123,7 @@ def make_library_info(dependencies, versions, headers):
             }
 
     for header in headers:
-        dep = _startswith_any(header, dependencies)
+        dep = header.startswith(tuple(dependencies))
         if dep and dep in libs:
             libs[dep]['headers'].append(header)
     return libs

--- a/tests/test_ycm.py
+++ b/tests/test_ycm.py
@@ -1,6 +1,6 @@
 """ These are integration tests which just exist to help with development. They are not particularly exhaustive are not
 run automatically.
-The dependencies test relies on the the git repo Spacerat/libname existing. """
+The dependencies test relies on the the git repo Katharine/pebble-events existing. """
 
 import unittest
 import subprocess
@@ -53,13 +53,13 @@ class TestYCM(unittest.TestCase):
         """ Check that YCM can autocomplete on external libraries. """
         try:
             uuid = self.spinup({
-                'files': {'main.c': LIBRARIES_CONTENT.format(include="libname/whatever.h", text="worl")},
-                'dependencies': {'libname': 'spacerat/libname'}
+                'files': {'main.c': LIBRARIES_CONTENT.format(include="pebble-events/pebble-events.h", text="even")},
+                'dependencies': {'pebble-events': '^1.0.0'}
             })
         except subprocess.CalledProcessError as e:
             print e.output
             raise
-        self.expect_completion(uuid, 6, 6, 'world')
+        self.expect_completion(uuid, 6, 6, 'events_health_service_events_unsubscribe')
 
     def test_namespaced_dependencies(self):
         """ Check that YCM can autocomplete on namespaced external libraries. """


### PR DESCRIPTION
This adds support for sending the list of non-transitive package header includes to CloudPebble, and also for sending back any npm installation errors on spinup while allowing the spinup to still succeed.

(depends on #9 )